### PR TITLE
Fix for "Malformed UTF-8 characters" error

### DIFF
--- a/src/TurboSmsApi.php
+++ b/src/TurboSmsApi.php
@@ -63,7 +63,7 @@ class TurboSmsApi
             if ($result->SendSMSResult->ResultArray[0]
               != 'Сообщения успешно отправлены'
             ) {
-                throw new DomainException($result->SendSMSResult->ResultArray[0]);
+                throw new DomainException($result->SendSMSResult->ResultArray);
             }
 
             return $result;


### PR DESCRIPTION
Backporting lost fix for "Malformed UTF-8 characters" error